### PR TITLE
Add features to enable TLS support in aliri-oauth2 directly

### DIFF
--- a/aliri_oauth2/Cargo.toml
+++ b/aliri_oauth2/Cargo.toml
@@ -15,6 +15,8 @@ ec = [ "aliri/ec" ]
 rsa = [ "aliri/rsa" ]
 hmac = [ "aliri/hmac" ]
 private-keys = [ "aliri/private-keys" ]
+rustls-tls = [ "reqwest/rustls-tls" ]
+default-tls = [ "reqwest/default-tls" ]
 default = [ "rsa", "reqwest", "tokio" ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Fixes #22

Users can specify whether to support TLS in aliri-oauth2 directly using the new features:

- default-tls
- rustls-tls

For example:
```toml
# No HTTPS Support
aliri_oauth2 = { version = "0.8", features = ["reqwest"] }

# HTTPS Support with OpenSSL
aliri_oauth2 = { version = "0.8", features = ["reqwest", "default-tls"] }

# HTTPS Support with Rustls
aliri_oauth2 = { version = "0.8", features = ["reqwest", "rustls-tls"] }
```