### PR TITLE
feat: Implement FromStr for Algorithm

### DIFF
--- a/aliri/src/error.rs
+++ b/aliri/src/error.rs
@@ -20,6 +20,18 @@ pub(crate) fn incompatible_algorithm(
     IncompatibleAlgorithm { alg: alg.into() }
 }
 
+/// The provided name could not be matched with supported algorithms
+#[derive(Debug, Error)]
+#[error("'{alg}' does not match supported algorithms")]
+pub struct UnknownAlgorithm {
+    alg: String,
+}
+
+#[inline]
+pub(crate) fn unknown_algorithm(alg: String) -> UnknownAlgorithm {
+    UnknownAlgorithm { alg }
+}
+
 /// The JWK has a specific usage that disallows this use
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Error)]
 #[error("JWK cannot be used in this way")]

--- a/aliri/src/jwa/algorithm.rs
+++ b/aliri/src/jwa/algorithm.rs
@@ -1,8 +1,11 @@
-use std::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{error, jwa, jws};
+use crate::{
+    error::{self, unknown_algorithm, UnknownAlgorithm},
+    jwa, jws,
+};
 
 /// An algorithm
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -67,6 +70,57 @@ impl Algorithm {
     pub const ES384: Algorithm = Self::Signing(jws::Algorithm::ES384);
     /// The ES512 signing algorithm
     pub const ES512: Algorithm = Self::Signing(jws::Algorithm::ES512);
+}
+
+impl TryFrom<&'_ str> for Algorithm {
+    type Error = UnknownAlgorithm;
+
+    #[inline]
+    fn try_from(value: &'_ str) -> Result<Self, Self::Error> {
+        match value {
+            #[cfg(feature = "ec")]
+            "ES256" => Ok(Algorithm::ES256),
+            #[cfg(feature = "ec")]
+            "ES384" => Ok(Algorithm::ES384),
+            #[cfg(feature = "ec")]
+            "ES512" => Ok(Algorithm::ES512),
+            #[cfg(feature = "rsa")]
+            "RS256" => Ok(Algorithm::RS256),
+            #[cfg(feature = "rsa")]
+            "RS384" => Ok(Algorithm::RS384),
+            #[cfg(feature = "rsa")]
+            "RS512" => Ok(Algorithm::RS512),
+            #[cfg(feature = "rsa")]
+            "PS256" => Ok(Algorithm::PS256),
+            #[cfg(feature = "rsa")]
+            "PS384" => Ok(Algorithm::PS384),
+            #[cfg(feature = "rsa")]
+            "PS512" => Ok(Algorithm::PS512),
+            #[cfg(feature = "hmac")]
+            "HS256" => Ok(Algorithm::HS256),
+            #[cfg(feature = "hmac")]
+            "HS384" => Ok(Algorithm::HS384),
+            #[cfg(feature = "hmac")]
+            "HS512" => Ok(Algorithm::HS512),
+            _ => Err(unknown_algorithm(value.to_string())),
+        }
+    }
+}
+
+impl TryFrom<String> for Algorithm {
+    type Error = UnknownAlgorithm;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = UnknownAlgorithm;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
 }
 
 impl<T> From<T> for Algorithm

--- a/aliri/src/jwa/algorithm.rs
+++ b/aliri/src/jwa/algorithm.rs
@@ -2,10 +2,7 @@ use std::{convert::TryFrom, fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    error::{self, unknown_algorithm, UnknownAlgorithm},
-    jwa, jws,
-};
+use crate::{error, jwa, jws};
 
 /// An algorithm
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,7 +70,7 @@ impl Algorithm {
 }
 
 impl TryFrom<&'_ str> for Algorithm {
-    type Error = UnknownAlgorithm;
+    type Error = error::UnknownAlgorithm;
 
     #[inline]
     fn try_from(value: &'_ str) -> Result<Self, Self::Error> {
@@ -102,13 +99,13 @@ impl TryFrom<&'_ str> for Algorithm {
             "HS384" => Ok(Algorithm::HS384),
             #[cfg(feature = "hmac")]
             "HS512" => Ok(Algorithm::HS512),
-            _ => Err(unknown_algorithm(value.to_string())),
+            _ => Err(error::unknown_algorithm(value.to_string())),
         }
     }
 }
 
 impl TryFrom<String> for Algorithm {
-    type Error = UnknownAlgorithm;
+    type Error = error::UnknownAlgorithm;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Self::try_from(value.as_str())
@@ -116,7 +113,7 @@ impl TryFrom<String> for Algorithm {
 }
 
 impl FromStr for Algorithm {
-    type Err = UnknownAlgorithm;
+    type Err = error::UnknownAlgorithm;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::try_from(s)


### PR DESCRIPTION
This contribution provides implementations for TryFrom <&'_ str> TryFrom<String> and FromStr. Now, `Algorithm` can be directly parsed by libraries like `clap`.