### PR TITLE
Improve logging

### DIFF
--- a/aliri_tower/src/jwt.rs
+++ b/aliri_tower/src/jwt.rs
@@ -159,6 +159,8 @@ delegate_impls!(
     std::sync::Arc<T>
 );
 
+const JWT_VALID_FAIL_MSG: &str = "JWT validation failed";
+
 impl<ResBody> OnJwtError for TerseErrorHandler<ResBody>
 where
     ResBody: Default,
@@ -167,19 +169,22 @@ where
 
     #[inline]
     fn on_missing_or_malformed(&self) -> Response<Self::Body> {
-        tracing::debug!("JWT validation failed: authorization token is missing or malformed");
+        tracing::debug!(
+            exception = as_std_err(&JwtMissingOrMalformed),
+            JWT_VALID_FAIL_MSG
+        );
         unauthorized("")
     }
 
     #[inline]
     fn on_no_matching_jwk(&self) -> Response<Self::Body> {
-        tracing::debug!("JWT validation failed: token signing key (kid) is not trusted");
+        tracing::debug!(exception = as_std_err(&NoMatchingJwk), JWT_VALID_FAIL_MSG);
         unauthorized("")
     }
 
     #[inline]
-    fn on_jwt_invalid(&self, _: JwtVerifyError) -> Response<Self::Body> {
-        tracing::debug!("JWT validation failed");
+    fn on_jwt_invalid(&self, error: JwtVerifyError) -> Response<Self::Body> {
+        tracing::debug!(exception = as_std_err(&error), JWT_VALID_FAIL_MSG);
         unauthorized("")
     }
 }
@@ -192,21 +197,24 @@ where
 
     #[inline]
     fn on_missing_or_malformed(&self) -> Response<Self::Body> {
-        let message = "authorization token is missing or malformed";
-        tracing::debug!("JWT validation failed: {message}");
-        unauthorized(message)
+        tracing::debug!(
+            exception = as_std_err(&JwtMissingOrMalformed),
+            JWT_VALID_FAIL_MSG
+        );
+        unauthorized(JwtMissingOrMalformed::ERROR_DESC)
     }
 
     #[inline]
     fn on_no_matching_jwk(&self) -> Response<Self::Body> {
-        let message = "token signing key (kid) is not trusted";
-        tracing::debug!("JWT validation failed: {message}");
-        unauthorized(message)
+        tracing::debug!(exception = as_std_err(&NoMatchingJwk), JWT_VALID_FAIL_MSG);
+        unauthorized(NoMatchingJwk::ERROR_DESC)
     }
 
     #[inline]
     fn on_jwt_invalid(&self, error: JwtVerifyError) -> Response<Self::Body> {
         use std::fmt::Write;
+
+        tracing::debug!(exception = as_std_err(&error), JWT_VALID_FAIL_MSG);
 
         let mut description = String::new();
         let mut err: &dyn std::error::Error = &error;
@@ -215,7 +223,6 @@ where
             write!(&mut description, ": {next}").unwrap();
             err = next;
         }
-        tracing::debug!("JWT validation failed: {description}");
         unauthorized(&description)
     }
 }
@@ -226,4 +233,41 @@ fn extract_jwt(auth: &str) -> Option<Jwt> {
     }
 
     Some(Jwt::from(auth[7..].trim()))
+}
+
+#[derive(Debug)]
+struct JwtMissingOrMalformed;
+
+impl JwtMissingOrMalformed {
+    const ERROR_DESC: &'static str = "token signing key (kid) is not trusted";
+}
+
+impl fmt::Display for JwtMissingOrMalformed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(Self::ERROR_DESC)
+    }
+}
+
+impl std::error::Error for JwtMissingOrMalformed {}
+
+#[derive(Debug)]
+struct NoMatchingJwk;
+
+impl NoMatchingJwk {
+    const ERROR_DESC: &'static str = "token signing key (kid) is not trusted";
+}
+
+impl fmt::Display for NoMatchingJwk {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(Self::ERROR_DESC)
+    }
+}
+
+impl std::error::Error for NoMatchingJwk {}
+
+/// Error type coercion helper
+const fn as_std_err<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> &'a (dyn std::error::Error + 'static) {
+    err
 }

--- a/aliri_tower/src/jwt.rs
+++ b/aliri_tower/src/jwt.rs
@@ -167,16 +167,19 @@ where
 
     #[inline]
     fn on_missing_or_malformed(&self) -> Response<Self::Body> {
+        tracing::debug!("JWT validation failed: authorization token is missing or malformed");
         unauthorized("")
     }
 
     #[inline]
     fn on_no_matching_jwk(&self) -> Response<Self::Body> {
+        tracing::debug!("JWT validation failed: token signing key (kid) is not trusted");
         unauthorized("")
     }
 
     #[inline]
     fn on_jwt_invalid(&self, _: JwtVerifyError) -> Response<Self::Body> {
+        tracing::debug!("JWT validation failed");
         unauthorized("")
     }
 }
@@ -189,12 +192,16 @@ where
 
     #[inline]
     fn on_missing_or_malformed(&self) -> Response<Self::Body> {
-        unauthorized("authorization token is missing or malformed")
+        let message = "authorization token is missing or malformed";
+        tracing::debug!("JWT validation failed: {message}");
+        unauthorized(message)
     }
 
     #[inline]
     fn on_no_matching_jwk(&self) -> Response<Self::Body> {
-        unauthorized("token signing key (kid) is not trusted")
+        let message = "token signing key (kid) is not trusted";
+        tracing::debug!("JWT validation failed: {message}");
+        unauthorized(message)
     }
 
     #[inline]
@@ -208,7 +215,7 @@ where
             write!(&mut description, ": {next}").unwrap();
             err = next;
         }
-
+        tracing::debug!("JWT validation failed: {description}");
         unauthorized(&description)
     }
 }


### PR DESCRIPTION
Before, the reason for a failed JWT validation could not be discovered
from the log output but only from the response headers.

This contribution fixes this by introducing additional debug outputs.

Blocked by: https://github.com/neoeinstein/aliri/pull/42