### PR TITLE
[aliri_axum] feat: support axum 0.7

### DIFF
--- a/aliri_axum/Cargo.toml
+++ b/aliri_axum/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/neoeinstein/aliri"
 aliri = { version = "0.6.0", path = "../aliri", default-features = false }
 aliri_oauth2 = { version = "0.10.0", path = "../aliri_oauth2", default-features = false }
 aliri_traits = { version = "0.1.1", path = "../aliri_traits" }
-axum-core = "0.3.0"
-http = "0.2.8"
+axum-core = "0.4.2"
+http = "1.0.0"
 once_cell = "1"
 
 [dev-dependencies]
@@ -25,8 +25,8 @@ aliri_base64 = { version = "0.1.5", path = "../aliri_base64" }
 aliri_braid = "0.4.0"
 aliri_clock = { version = "0.1.4", path = "../aliri_clock" }
 aliri_oauth2 = { version = "0.10.0", path = "../aliri_oauth2", features = ["rsa", "tokio", "reqwest"] }
-aliri_tower = { version = "0.5.0", path = "../aliri_tower" }
-axum = { version = "0.6", default-features = false, features = ["tokio"] }
+aliri_tower = { version = "0.6.0", path = "../aliri_tower" }
+axum = { version = "0.7.3", default-features = false, features = ["tokio", "http1"] }
 color-eyre = "0.6.1"
 reqwest = "0.11.11"
 serde = { version = "1.0.137", features = [ "derive" ] }

--- a/aliri_axum/examples/auth0_server.rs
+++ b/aliri_axum/examples/auth0_server.rs
@@ -13,6 +13,7 @@ use axum::{
 };
 use http::{request::Parts, Response};
 use time::format_description::well_known::Rfc3339;
+use tokio::net::TcpListener;
 
 scope_guards! {
     type Claims = CustomClaims;
@@ -54,10 +55,9 @@ async fn main() -> color_eyre::Result<()> {
     );
     println!("Press Ctrl+C to exit");
 
-    axum::Server::bind(&"127.0.0.1:8080".parse().unwrap())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:8000").await.unwrap();
+    let router  = app.into_make_service();
+    axum::serve(listener, router).await.unwrap();
 
     Ok(())
 }
@@ -165,7 +165,7 @@ impl HasScope for CustomClaims {
 struct MyErrorHandler;
 
 impl aliri_tower::OnJwtError for MyErrorHandler {
-    type Body = axum::body::BoxBody;
+    type Body = axum::body::Body;
 
     fn on_missing_or_malformed(&self) -> Response<Self::Body> {
         let (parts, ()) =

--- a/aliri_axum/examples/axum.rs
+++ b/aliri_axum/examples/axum.rs
@@ -9,6 +9,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use tokio::net::TcpListener;
 
 scope_guards! {
     type Claims = CustomClaims;
@@ -32,10 +33,9 @@ async fn main() {
 
     println!("Press Ctrl+C to exit");
 
-    axum::Server::bind(&"127.0.0.1:8080".parse().unwrap())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:8000").await.unwrap();
+    let router  = app.into_make_service();
+    axum::serve(listener, router).await.unwrap();
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/aliri_axum/src/lib.rs
+++ b/aliri_axum/src/lib.rs
@@ -13,12 +13,13 @@
 //!     http::StatusCode,
 //!     response::{IntoResponse, Response},
 //!     routing::{get, post},
-//!     Server, Router,
+//!     Router,
 //! };
 //! use std::net::SocketAddr;
 //! use serde::Deserialize;
+//! use tokio::net::TcpListener;
 //!
-//! #[derive(Debug, Deserialize)]
+//! #[derive(Debug, Deserialize, Clone)]
 //! pub struct CustomClaims {
 //!     iss: jwt::Issuer,
 //!     aud: jwt::Audiences,
@@ -92,10 +93,8 @@
 //!     // .layer(axum::Extension(aliri_axum::VerboseAuthxErrors));
 //!
 //!     // Construct the server
-//!     let server = Server::bind(&SocketAddr::new([0, 0, 0, 0].into(), 3000))
-//!         .serve(router.into_make_service())
-//!         .await
-//!         .unwrap();
+//!     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+//!     axum::serve(listener, router.into_make_service()).await.unwrap();
 //!
 //!     Ok(())
 //! }

--- a/aliri_axum/src/macros.rs
+++ b/aliri_axum/src/macros.rs
@@ -59,8 +59,9 @@
 /// ```no_run
 /// use aliri_axum::scope_guard;
 /// use axum::routing::get;
-/// use axum::{Router, Server};
+/// use axum::Router;
 /// use std::net::SocketAddr;
+/// use tokio::net::TcpListener;
 ///
 /// // Define our initial scope
 /// scope_guard!(AdminOnly; "admin");
@@ -75,11 +76,9 @@
 /// let router = Router::new()
 ///     .route("/test", get(test_endpoint));
 ///
-/// // Construct the server
-/// let server = Server::bind(&SocketAddr::new([0, 0, 0, 0].into(), 3000))
-///     .serve(router.into_make_service())
-///     .await
-///     .unwrap();
+/// // Construct the server///
+/// let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+/// axum::serve(listener, router.into_make_service()).await.unwrap();
 /// # }
 /// ```
 ///
@@ -332,6 +331,7 @@ mod tests {
         scope TestingAdmin = ["testing admin"];
     }
 
+    #[derive(Clone)]
     struct MyClaims(Scope);
 
     impl HasScope for MyClaims {

--- a/aliri_tower/Cargo.toml
+++ b/aliri_tower/Cargo.toml
@@ -17,22 +17,23 @@ aliri = { version = "0.6.0", path = "../aliri" }
 aliri_traits = { version = "0.1.1", path = "../aliri_traits" }
 aliri_oauth2 = { version = "0.10.0", path = "../aliri_oauth2", features = [ "reqwest" ] }
 bytes = "1.1.0"
-http = "0.2"
-http-body = "0.4.4"
+http = "1.0.0"
+http-body = "1.0.0"
 serde = { version = "1", features = [ "derive" ] }
 thiserror = "1"
 tracing = "0.1"
 tower-layer = { version = "0.3.1" }
-tower-http = { version = "0.4", features = [ "validate-request" ] }
+tower-http = { version = "0.5.0", features = [ "validate-request" ] }
 
 [dev-dependencies]
 aliri_braid = "0.4.0"
 aliri_base64 = { version = "0.1.5", path = "../aliri_base64" }
 aliri_clock = { version = "0.1.4", path = "../aliri_clock" }
-axum = { version = "0.6", default-features = false }
+axum = { version = "0.7.3", default-features = false }
 prost = "0.11.2"
 tokio = { version = "1", features = [ "rt-multi-thread", "macros" ] }
-tonic = { version = "0.9.2", features = ["gzip"] }
+# Blocked by https://github.com/hyperium/tonic/issues/1579
+#tonic = { version = "0.10.2", features = ["gzip"] }
 tower = "0.4.13"
 regex = "1"
 

--- a/aliri_tower/src/authorizer.rs
+++ b/aliri_tower/src/authorizer.rs
@@ -111,7 +111,7 @@ impl<Claims, OnError> Oauth2Authorizer<Claims, OnError>
 where
     OnError: OnJwtError + Clone,
     OnError::Body: Body + Default,
-    Claims: for<'de> serde::Deserialize<'de> + HasScope + CoreClaims + Send + Sync + 'static,
+    Claims: for<'de> serde::Deserialize<'de> + HasScope + CoreClaims + Send + Sync + Clone + 'static,
 {
     /// Authorizer layer that verifies the validity of a JWT
     ///

--- a/aliri_tower/src/jwt.rs
+++ b/aliri_tower/src/jwt.rs
@@ -71,7 +71,7 @@ impl<Claims, OnError, ReqBody> ValidateRequest<ReqBody> for VerifyJwt<Claims, On
 where
     OnError: OnJwtError,
     OnError::Body: Body + Default,
-    Claims: for<'de> serde::Deserialize<'de> + HasScope + CoreClaims + Send + Sync + 'static,
+    Claims: for<'de> serde::Deserialize<'de> + HasScope + CoreClaims + Send + Sync + Clone + 'static,
 {
     type ResponseBody = OnError::Body;
 


### PR DESCRIPTION
resolves #44  

Support of axum 0.7 following the axum release note as upgrade path.

Blockers:
-[ ] https://github.com/seanmonstar/reqwest/issues/2039: Upgrade to hyper 1.0
-[ ] https://github.com/hyperium/tonic/issues/1579: Upgrade to http 1.0 and axum 0.7