### PR TITLE
fix(deps): update rust crate reqwest to v0.12.3

### DIFF
--- a/aliri_axum/Cargo.toml
+++ b/aliri_axum/Cargo.toml
@@ -28,7 +28,7 @@ aliri_oauth2 = { version = "0.10.0", path = "../aliri_oauth2", features = ["rsa"
 aliri_tower = { version = "0.5.0", path = "../aliri_tower" }
 axum = { version = "0.6", default-features = false, features = ["tokio"] }
 color-eyre = "0.6.3"
-reqwest = "0.11.11"
+reqwest = "0.12.3"
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde_json = "1"
 time = { version = "0.3.34", features = ["formatting"] }

--- a/aliri_oauth2/Cargo.toml
+++ b/aliri_oauth2/Cargo.toml
@@ -30,7 +30,7 @@ aliri_traits = { version = "0.1.0", path = "../aliri_traits" }
 aliri_braid = { version = "0.4.0" }
 arc-swap = "1.7"
 compact_str = { version = "0.7.1", features = ["serde"] }
-reqwest = { version = "0.11", optional = true, default-features = false, features = [ "json" ] }
+reqwest = { version = "0.12", optional = true, default-features = false, features = [ "json" ] }
 serde = { version = "1", features = [ "derive" ] }
 thiserror = "1"
 tokio = { version = "1", features = [ "time" ], optional = true }


### PR DESCRIPTION
Updates reqwest in crates where the Client is not publicly exposed in the API